### PR TITLE
QOL Nerfing Fire tick on blaze

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1707,7 +1707,7 @@ export class Character2016 extends BaseFullCharacter {
         server.applyCharacterEffect(
           this,
           Effects.PFX_Fire_Person_loop,
-          500,
+          400,
           10000
         );
         break;


### PR DESCRIPTION
Slightly nerfing the fire tick on blaze so you dont die from one single shot to the head.

Now you end up on 16 health + possible bleeding effect

